### PR TITLE
fix: Assigning an Attach::File directly to a model

### DIFF
--- a/lib/attach/attachment.rb
+++ b/lib/attach/attachment.rb
@@ -103,7 +103,7 @@ module Attach
         self.file_name = file.original_filename
         self.file_type = file.content_type
       when 'Attach::File'
-        self.binary = BlobTypes::Raw.new(file.data)
+        self.blob = BlobTypes::Raw.new(file.data)
         self.file_name = file.name
         self.file_type = file.type
       else


### PR DESCRIPTION
Currently when attaching an instance of `Attach::File` to an `ApplicationRecord` the following error will be raised:

```ruby
SomeModel.new(
  attachable_file: Attach::File.new("file content...")
)

# => NoMethodError:
#      undefined method `binary=' for #<Attach::Attachment id: nil ... >
```

Changing `self.binary =` to `self.blob =` in lib/attach/attachment.rb:106 to match the other cases fixes the issue.